### PR TITLE
fix 'burndown chart cannot be redirect' issue when click 'Burndown' link in 'Sprint Brundown List' screen

### DIFF
--- a/src/storage/SprintListDataProvider.php
+++ b/src/storage/SprintListDataProvider.php
@@ -69,14 +69,14 @@ final class SprintListDataProvider {
         phutil_tag(
         'a',
         array(
-            'href' => '/project/sprint/profile/'.$project_id,
+            'href' => '/project/sprint/profile/'.$project_id.'/',
             'style' => 'font-weight:bold',
         ),
             $project_name),
         phutil_tag(
             'a',
             array(
-                'href'  => '/project/sprint/view/'.$project_id,
+                'href'  => '/project/sprint/view/'.$project_id.'/',
              ),
             $this->getEditProjectDetailsIcon()),
         $start,


### PR DESCRIPTION
There are two link in 'Sprint Burndown List' screen which cannot redirect automatically to next page, one is 'Sprint Name', another one is 'Burndown'. 

Need to append '/' at the end of link, otherwise phabricator server will return 404 error when click it. Or force refresh browser by press key 'F5'.