### PR TITLE
Realign Phabricator master

### DIFF
--- a/src/application/SprintApplication.php
+++ b/src/application/SprintApplication.php
@@ -56,13 +56,15 @@ final class SprintApplication extends PhabricatorApplication {
         ),
         ManiphestDefaultEditCapability::CAPABILITY => array(
             'caption' => pht('Default edit policy for newly created tasks.'),
-        ),
-        ManiphestEditStatusCapability::CAPABILITY => array(),
+        )
+        /*
+        ,
         ManiphestEditAssignCapability::CAPABILITY => array(),
         ManiphestEditPoliciesCapability::CAPABILITY => array(),
         ManiphestEditPriorityCapability::CAPABILITY => array(),
         ManiphestEditProjectsCapability::CAPABILITY => array(),
         ManiphestBulkEditCapability::CAPABILITY => array(),
+        */
     );
   }
 }

--- a/src/storage/SprintListDataProvider.php
+++ b/src/storage/SprintListDataProvider.php
@@ -69,14 +69,14 @@ final class SprintListDataProvider {
         phutil_tag(
         'a',
         array(
-            'href' => '/project/sprint/profile/'.$project_id,
+            'href' => '/project/sprint/profile/'.$project_id .'/',
             'style' => 'font-weight:bold',
         ),
             $project_name),
         phutil_tag(
             'a',
             array(
-                'href'  => '/project/sprint/view/'.$project_id,
+                'href'  => '/project/sprint/view/'.$project_id . '/',
              ),
             $this->getEditProjectDetailsIcon()),
         $start,

--- a/src/view/reports/SprintReportBurnUpView.php
+++ b/src/view/reports/SprintReportBurnUpView.php
@@ -32,7 +32,7 @@ final class SprintReportBurnUpView extends SprintView {
   private function getXactionData($project_phid) {
      $query = id(new SprintQuery())
         ->setPHID($project_phid);
-      $data = $query->getXactionData(ManiphestTransaction::TYPE_STATUS);
+      $data = $query->getXactionData(ManiphestTaskStatusTransaction::TRANSACTIONTYPE);
     return $data;
   }
 


### PR DESCRIPTION
Class `ManiphestEditStatusCapability` has been removed from Phabricator code base, and phabricator-extensions-Sprint is still using it. This fix all the extension to work again with latest Phabricator stable branch.